### PR TITLE
004 feat: setup nginx container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     container_name: backendDummy
     build:
       context: ./srcs/backend
-    ports:
-      - 8000:8000
     # command: python manage.py runserver
     volumes:
       - ./srcs/backend/beePong:/usr/src/backend/beePong
@@ -13,16 +11,14 @@ services:
   #   image: postgres:16
   #   volumes:
   #     - postgres_data:/var/lib/postgresql/data/
-  # nginx: 
-  #   container_name: nginx
-  #   depends_on:
-  #     - backendDummy
-  #   build:
-  #     context: ./srcs/nginx
-  #   env_file:
-  #     - .env
-  #   volumes:
-  #     - .srcs/backend/beePong:/beePong/app
-  #   ports:
-  #     - 127.0.0.1:8000:8000
-  #   restart: on-failure
+  nginx:
+    container_name: nginx
+    depends_on:
+      - backend_dummy
+    build:
+      context: ./srcs/nginx
+    volumes:
+      - ./srcs/frontend:/var/www/html
+    ports:
+      - 443:443
+    restart: on-failure

--- a/srcs/backend/accounts/templates/registration/register.html
+++ b/srcs/backend/accounts/templates/registration/register.html
@@ -1,12 +1,6 @@
-{% extends 'beePong/base.html' %}
-
-{% block content %}
-
 <form action="{% url 'accounts:register' %}" method='post'>
     {% csrf_token %}
     {{ form.as_div }}
 
     <button type="submit">Register</button>
 </form>
-
-{% endblock content %}

--- a/srcs/backend/bpong_project/settings.py
+++ b/srcs/backend/bpong_project/settings.py
@@ -136,3 +136,7 @@ LOGIN_REDIRECT_URL = 'beePong:index'
 # Tells Django to redirect logged-out users back to the home page
 LOGOUT_REDIRECT_URL = 'beePong:index'
 LOGIN_URL = 'accounts:login'
+
+# List of trusted origins for CSRF protection
+# Requests from these origins will be allowed to bypass the CSRF protection
+CSRF_TRUSTED_ORIGINS = ['https://localhost']

--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dummy BeePong</title>
+    <script>
+        function getCookie(name) {
+            let cookieValue = null;
+            if (document.cookie && document.cookie !== '') {
+                const cookies = document.cookie.split(';');
+                for (let i = 0; i < cookies.length; i++) {
+                    const cookie = cookies[i].trim();
+                    // Does this cookie string begin with the name we want?
+                    if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        }
+
+        async function fetchRegisterPage() {
+            const csrftoken = getCookie('csrftoken');
+            try {
+                const response = await fetch('/accounts/register/', {
+                    method: 'GET',
+                    headers: {
+                        'X-CSRFToken': csrftoken
+                    }
+                });
+                if (!response.ok) {
+                    throw new Error('Network response was not ok ' + response.statusText);
+                }
+                const data = await response.text(); // or response.json() if the API returns JSON
+                document.getElementById('register').innerHTML = data;
+            } catch (error) {
+                console.error('There was a problem with the fetch operation:', error);
+                document.getElementById('register').innerHTML = '<p>Failed to load the registration page. Please try again later.</p>';
+            }
+        }
+        async function fetchTestData() {
+            const response = await fetch('/api/');
+            const data = await response.text(); // or response.json() if the API returns JSON
+            document.getElementById('test').innerHTML = data;
+        }
+    </script>
+</head>
+
+<body>
+    <div>
+        <button onclick="fetchRegisterPage()">Register</button>
+        <div id="register"></div>
+        <button onclick="fetchTestData()">test</button>
+        <div id="test"></div>
+    </div>
+</body>
+
+</html>

--- a/srcs/nginx/Dockerfile
+++ b/srcs/nginx/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:3.18.6
+
+RUN apk update && apk add --no-cache nginx openssl
+
+RUN adduser -D -g 'www' www && \
+	mkdir /www && chown -R www:www /var/lib/nginx && \
+	chown -R www:www /www
+
+RUN mkdir /etc/nginx/ssl && \
+	sed -i 's/user nginx;/user www;/' /etc/nginx/nginx.conf
+
+RUN openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+	-out /etc/nginx/ssl/beepong.csr \
+	-keyout /etc/nginx/ssl/beepong.key \
+	-subj "/C=FI/ST=Helsinki/L=Helsinki/O=beepong/OU=beepong/CN=beepong"
+
+COPY ./nginx.conf /etc/nginx/http.d/default.conf
+
+EXPOSE 443
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/srcs/nginx/nginx.conf
+++ b/srcs/nginx/nginx.conf
@@ -1,0 +1,31 @@
+server {
+	listen [::]:443 ssl;
+	listen 443 ssl;
+
+	ssl_certificate /etc/nginx/ssl/beepong.csr;
+	ssl_certificate_key /etc/nginx/ssl/beepong.key;
+	ssl_protocols TLSv1.2 TLSv1.3;
+
+	# Root directory and index file for the server
+	root /var/www/html;
+	index index.html;
+
+	# Handle requests for the root URL and try to serve files directly
+	location / {
+			try_files $uri $uri/ =404;
+	}
+
+	# Proxy settings for /api and /accounts/register endpoints
+	location ~ ^/(api|accounts/register) {
+			proxy_pass http://backend_dummy:8000;
+			proxy_http_version 1.1;
+			proxy_set_header Host $host;
+			proxy_set_header X-Real-IP $remote_addr;
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+			proxy_set_header X-Forwarded-Proto $scheme;
+	}
+
+	# for websocket
+	# proxy_set_header Upgrade $http_upgrade;
+  # proxy_set_header Connection 'upgrade';
+}


### PR DESCRIPTION
Close #4

@pixelsnow  @liocle  @djames9 

I have set up nginx as the reverse proxy to serve frontend and proxy requests to the backend.

Run:

`make`

Open https://localhost/ and select Details and then Visit this unsafe site on your browser or if you are running it on codespaces, click open browser link that codespaces gives, or find the link under Ports.

I have put the registration form in the index page and will work on routing in issue #11.