### PR TITLE
Update Makefile to get access and error logs from nginx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ re_all_elk: clean_all up_all
 ################################################################################
 # Tail logs from specific services
 logs_nginx:
-	docker compose -f ./docker-compose.yml logs -f nginx
+	docker container exec -it beepong-nginx sh -c "cat /var/log/nginx/access.log && cat /var/log/nginx/error.log"
 
 logs_backend:
 	docker compose -f ./docker-compose.yml logs -f backend_dummy


### PR DESCRIPTION
This pull request attempts to fix the missing nginx logs. I have modified the old rule 'make logs_nginx' that was, I guess, showing only error.log. Now, it 'cat's both file in 'nginx' container located in /var/log/nginx/

Close#050