### PR TITLE
Feature/028 frontend add remote authentication in login and registration page

### DIFF
--- a/srcs/backend/accounts/templates/registration/form.html
+++ b/srcs/backend/accounts/templates/registration/form.html
@@ -16,15 +16,9 @@
 			</div>
 			<div class="form-error-message">
 			</div>
-			<div class="button-group--horizontal">
-					<button class="button--secondary button--with-icon">
-							<span class="font-size--xl">G</span>
-							LOGIN
-					</button>
-					<button class="button--secondary button--with-icon">
-							<img src="/img/42.png" alt="42 logo" class="fortytwo-icon" width="30" height="30">
-							<span>LOGIN</span>
-					</button>
-			</div>
+			<a id="login-42-url" href="{{ login_42_url }}">
+				<img src="/img/42.png" alt="42 logo" class="fortytwo-icon" width="30" height="30">
+				<span>LOGIN</span>
+			</a>
 	</div>
 </section>

--- a/srcs/backend/accounts/templates/registration/oauth_error.html
+++ b/srcs/backend/accounts/templates/registration/oauth_error.html
@@ -1,2 +1,2 @@
-<p>error</p>
-<button>go to login page</button>
+<p style="margin-bottom: 1em;">42 Authorization Error</p>
+<button class="button--primary" onclick="navigate('/')">Back to Homepage</button>

--- a/srcs/backend/accounts/templates/registration/oauth_error.html
+++ b/srcs/backend/accounts/templates/registration/oauth_error.html
@@ -1,0 +1,2 @@
+<p>error</p>
+<button>go to login page</button>

--- a/srcs/backend/accounts/urls.py
+++ b/srcs/backend/accounts/urls.py
@@ -16,4 +16,5 @@ urlpatterns = [
     path('login/', views.custom_login, name='login'),
     path('logout/', views.custom_logout, name='logout'),
     path('oauth_token/', views.oauth_token, name='oauth_token'),
+    path('oauth_error/', views.oauth_error, name='oauth_error'),
 ]

--- a/srcs/backend/beePong/templates/beePong/home.html
+++ b/srcs/backend/beePong/templates/beePong/home.html
@@ -20,6 +20,3 @@
 		<p class="font--alt font-size--sm">*created by 5 ultra talanted Hive Helsinki students. Tech stuff here -></p>
 	</div>
 </section>
-<a href="{{ 42_login_url }}">42Login</a>
-
-

--- a/srcs/backend/beePong/views.py
+++ b/srcs/backend/beePong/views.py
@@ -3,8 +3,6 @@ from django.shortcuts import render, redirect
 from django.http import Http404
 from django.http import JsonResponse
 from accounts.forms import CustomAuthenticationForm
-import os
-from urllib.parse import urlencode
 from collections import namedtuple
 
 # Create your views here.
@@ -19,16 +17,7 @@ def navbar(request):
 
 def home(request):
     """The home page for BeePong."""
-    params = {
-        'client_id': os.getenv('FTAPI_UID'),
-        'redirect_uri': os.getenv('FTAPI_REDIR_URL'),
-        'response_type': 'code',
-        'scope': 'public',
-        'state': 'qwerty',
-    }
-    login_url = f"https://api.intra.42.fr/oauth/authorize?{urlencode(params)}"
-    return render(request, 'beePong/home.html', {'42_login_url': login_url})
-    # return render(request, 'beePong/home.html')
+    return render(request, 'beePong/home.html')
 
 def about(request):
     """The about page for BeePong."""

--- a/srcs/frontend/js/route.js
+++ b/srcs/frontend/js/route.js
@@ -45,8 +45,8 @@ async function loadPage(path, redirectUrl = '/', fromNavigate = false) {
 				document.getElementById('content').innerHTML = data;
 
 				// Add the redirect url for login and register page 
-				if (page === '/accounts/login' || page === '/accounts/register')
-					document.getElementById('redirectUrl').value = redirectUrl;
+				if ((page === '/accounts/login' || page === '/accounts/register') && redirectUrl !== '/')
+					changeRedirectUrlandOauthState(redirectUrl);
 
 				// perform countdown in tournmament lobby if the list is full. Otherwise, wait for other players.
 				if (/^\/tournament\/\d+\/lobby$/.test(page))
@@ -70,11 +70,26 @@ async function redirectToLoginPage(redirectUrl) {
 		}
 		const data = await response.text();
 		document.getElementById('content').innerHTML = data;
-		document.getElementById('redirectUrl').value = redirectUrl;
+
+		changeRedirectUrlandOauthState(redirectUrl);
 	}
 	catch (error) {
 		console.error('There was a problem with the fetch operation:', error);
 	}
+}
+
+function changeRedirectUrlandOauthState(redirectUrl) {
+	// Change the redirect url in the form
+	document.getElementById('redirectUrl').value = redirectUrl;
+
+	// Change the state of the oauth according to the redirect url
+	const login42UrlElement = document.getElementById('login-42-url');
+
+	const updatedLogin42Url = new URL(login42UrlElement.href);
+	const newStateParam = `qwerty|${encodeURIComponent(`https://localhost${redirectUrl}`)}`;
+	updatedLogin42Url.searchParams.set('state', newStateParam);
+
+	login42UrlElement.href = updatedLogin42Url.toString();
 }
 
 // TODO: replace by websocket

--- a/srcs/nginx/nginx.conf
+++ b/srcs/nginx/nginx.conf
@@ -16,9 +16,10 @@ server {
 	}
 
 	# Proxy settings for /api, /page and /form endpoints
-	location ~ ^/(page|form) {
+	location ~ ^/(page|form|oauth) {
         rewrite ^/page(.*)$ $1 break;
         rewrite ^/form(.*)$ $1 break;
+				rewrite ^/oauth(.*)$ $1 break;
         proxy_pass http://backend_dummy:8000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
Close #28

@liocle @djames9 

I have moved the 42 login from home page to login and register page. Now after you login with 42, it should redirect you back to our website.

@linhtng I have appended an url to the state for oauth so that I can know where I should redirect after login. For example, if you click tournament and then 42 login, you will be redirected to the tournamnet. And if you click login button from the navbar and then 42 login, you will be redirected to the home page.

For error handling, I have added an error page so that it can respond with status 400 and show the error messge. @pixelsnow we can change its content and style later on with other error pages.

![image](https://github.com/user-attachments/assets/f726457f-31bb-4934-aa48-5bd52d2a3cf2)
