### PR TITLE
ExpandingBrowserCompatibility/Use cypress to test with firefox 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down clean clean_volumes clean_orphans clean_images clean_all get_images_id re re_elk re_all re_all_elk  up_backend up_db up_elk up_all up_no_elk logs logs_errors logs_grep logs_nginx logs_backend logs_db logs_elk ps ps_short ps_inspect exec_nginx exec_backend exec_db exec_elk stop_all stats sys_df help nuke jest cypress
+.PHONY: up down clean clean_volumes clean_orphans clean_images clean_all get_images_id re re_elk re_all re_all_elk  up_backend up_db up_elk up_all up_no_elk logs logs_errors logs_grep logs_nginx logs_backend logs_db logs_elk ps ps_short ps_inspect exec_nginx exec_backend exec_db exec_elk stop_all stats sys_df help nuke jest run_jest cypress run_cypress cypress_firefox run_cypress_firefox
 
 ################################################################################
 # Build and Start
@@ -181,7 +181,39 @@ sys_df:
 ################################################################################
 nuke:
 	git clean -dxf
-	git reset --hard	
+	git reset --hard
+
+
+################################################################################
+# Tests
+################################################################################
+# Build and run jest
+jest:
+	docker compose build jest
+	docker compose run --rm jest
+
+# Run jest
+run_jest:
+	docker compose run --rm jest
+
+# Build and run cypress
+cypress:
+	docker compose build cypress
+	docker compose run --rm cypress
+
+# Run cypress
+run_cypress:
+	docker compose run --rm cypress
+
+# Build and run cypress with firefox
+cypress_firefox:
+	docker compose build cypress
+	CYPRESS_BROWSER=firefox docker compose run --rm cypress
+
+# Run cypress with firefox
+run_cypress_firefox:
+	CYPRESS_BROWSER=firefox docker compose run --rm cypress
+
 
 ################################################################################
 # Help
@@ -244,18 +276,14 @@ help:
 	@echo "Reset repository:"
 	@echo "  nuke           Reset repository to the last commit (destructive action, removes all untracked files)"
 	@echo ""
+	@echo "Tests:"
+	@echo "  jest           Build and run jest"
+	@echo "  run_jest       Run jest"
+	@echo "  cypress        Build and run cypress"
+	@echo "  run_cypress    Run cypress"
+	@echo "  cypress_firefox Build and run cypress with firefox"
+	@echo "  run_cypress_firefox Run cypress with firefox"
+	@echo ""
 	@echo "Help:"
 	@echo "  help           Show this help message"
 
-################################################################################
-# Build and Run test
-################################################################################
-# Build and run jest
-jest:
-	docker compose build jest
-	docker compose run --rm jest
-
-# Build and run cypress
-cypress:
-	docker compose build cypress
-	docker compose run --rm cypress

--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   e2e: {
     baseUrl:  'https://nginx',
+    video: false,
 		setupNodeEvents(on, config) {
       // implement node event listeners here
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,8 +110,11 @@ services:
       dockerfile: Dockerfile
     environment:
       - CYPRESS_baseUrl=https://nginx
+      - CYPRESS_BROWSER=${CYPRESS_BROWSER:-chrome}
     depends_on:
       - nginx
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["npx cypress run --browser ${CYPRESS_BROWSER:-chrome}"]
 
   pgadmin:
     container_name: beepong-pgadmin


### PR DESCRIPTION
@pixelsnow @linhtng @djames9 

Just discovered this point in the subject for Expanding Browser Compatibility module:
- Conduct thorough testing and optimization to ensure that the web application functions correctly and displays correctly in the newly supported browser.

I think it will be nice to set up cypress to test with firebox though we can argue that testing could be manual testing.

Here are the changes that I made in this PR:
1) Add the command for using cypress for firebox
2) Add commands for running tests only, without building
3) Add the testing commands to make help


Run the tests with the commands:

make  jest                              Build and run jest
make run_jest                        Run jest
make cypress                         Build and run cypress
make run_cypress                  Run cypress
make cypress_firefox             Build and run cypress with firefox
make run_cypress_firefox      Run cypress with firefox


Related to #8 , #70 