### PR TITLE
fix invalid tournament lobby page crashing

### DIFF
--- a/srcs/backend/tournament/templates/tournament/tournament.html
+++ b/srcs/backend/tournament/templates/tournament/tournament.html
@@ -40,21 +40,23 @@
 						{% endfor %}
 					</div>
 					{% if tournament.state == 'NEW' %}
-					<form onsubmit="handleFormSubmit(event)" action="{{ form_action }}">
-						{% csrf_token %}
-						<input type="hidden" name="tournament_id" value="{{ tournament.tournament_id }}">
-						<div class="form__input-button-container">
-							<div>
-								<label for="id_alias">Alias</label>
-								{{ form.alias }}
+					<div class="form__actions">
+						<form onsubmit="handleFormSubmit(event)" action="{{ form_action }}">
+							{% csrf_token %}
+							<input type="hidden" name="tournament_id" value="{{ tournament.tournament_id }}">
+							<div class="form__input-button-container">
+								<div>
+									<label for="id_alias">Alias</label>
+									{{ form.alias }}
+								</div>
+								<button type="submit" class="button--primary button--with-icon">
+									<span class="button__text">JOIN</span>
+									<img src="/img/arrow.svg" alt="arrow" width="21" height="12">
+								</button>
 							</div>
-							<button type="submit" class="button--primary button--with-icon">
-								<span class="button__text">JOIN</span>
-								<img src="/img/arrow.svg" alt="arrow" width="21" height="12">
-							</button>
-						</div>
-					</form>
-					<div class="form__error-message"></div>  
+						</form>
+						<div class="form__error-message"></div>
+					</div>
 					{% endif %}
 				</div>
 			</div>

--- a/srcs/backend/tournament/views.py
+++ b/srcs/backend/tournament/views.py
@@ -10,6 +10,7 @@ from .decorators import login_required_json
 from django.utils.functional import SimpleLazyObject
 from django.shortcuts import render, redirect, get_object_or_404
 from django.urls import reverse
+from beePong.views import custom_404
 # Create your views here.
 
 @login_required_json
@@ -21,34 +22,37 @@ def tournament(request):
         tournaments = Tournament.objects.all().order_by('-tournament_id')
         form = AliasForm(username=request.user.username)
     else:
-        tournament_id = request.POST.get('tournament_id')
-        #username = request.session.get('username', None)
-        form = AliasForm(data=request.POST, instance=player)
-        if form.is_valid():
-            if player.has_active_tournament == False:
-                form.save()
-         #Safely retrieve the tournament object
-            tournament = get_object_or_404(Tournament, tournament_id=tournament_id)
-            if tournament.state != 'READY':
-                #user1 = request.user
-                list_players = tournament.players
-                if player.alias in list_players:
-                    print(f"{player.alias} is in the list.")
-                else:
-                    print(f"{player.alias} is not in the list.")
-                    player.is_online = True
-                    if player.has_active_tournament == False:
-                        player.current_tournament_id = tournament_id
-                        player.has_active_tournament = True
-                        player.save()
-                        tournament.players.append(player.alias)
-                        tournament.num_players_in += 1
-                if tournament.num_players_in >= tournament.num_players:
-                   tournament.state = 'READY'
-                tournament.save()
-            return JsonResponse({'success': True, 'redirect': f'/tournament/{tournament_id}/lobby'}, status=201)
-        else:
-            return JsonResponse({'success': False, 'errors': form.errors}, status=400)
+        try:
+            tournament_id = request.POST.get('tournament_id')
+            #username = request.session.get('username', None)
+            form = AliasForm(data=request.POST, instance=player)
+            if form.is_valid():
+                if player.has_active_tournament == False:
+                    form.save()
+            #Safely retrieve the tournament object
+                tournament = get_object_or_404(Tournament, tournament_id=tournament_id)
+                if tournament.state != 'READY':
+                    #user1 = request.user
+                    list_players = tournament.players
+                    if player.alias in list_players:
+                        print(f"{player.alias} is in the list.")
+                    else:
+                        print(f"{player.alias} is not in the list.")
+                        player.is_online = True
+                        if player.has_active_tournament == False:
+                            player.current_tournament_id = tournament_id
+                            player.has_active_tournament = True
+                            player.save()
+                            tournament.players.append(player.alias)
+                            tournament.num_players_in += 1
+                    if tournament.num_players_in >= tournament.num_players:
+                        tournament.state = 'READY'
+                    tournament.save()
+                return JsonResponse({'success': True, 'redirect': f'/tournament/{tournament_id}/lobby'}, status=201)
+            else:
+                return JsonResponse({'success': False, 'errors': form.errors}, status=400)
+        except Exception as error:
+            return JsonResponse({'success': False, 'errors': {'tournament_id': ['Invalid tournament ID']}}, status=400)
     
     # Prepare tournaments data for the template
     tournament_data = []
@@ -116,4 +120,4 @@ def tournament_lobby(request, tournament_id):
         else:
             return render(request, 'tournament/tournament_full_lobby.html', {'match_players': tournament.players, 'players_in_lobby': tournament.players, 'num_players': tournament.num_players, 'lose_players': lose_players, 'is_final': tournament.is_final})
     except Exception as error:
-        return JsonResponse({'success': False, 'error': error}, status=404)
+        return custom_404(request, None)


### PR DESCRIPTION
@linhtng @liocle @djames9 

Here is the fix for the crashing when user tries to access lobby of a non-existent tournament directly as reported in #60.

There is a crash because the exception handling for `get_object_or_404()` in `tournament_lobby` returns json instead of html. Now it is fixed to return the custom 404 page.

![image](https://github.com/user-attachments/assets/1b9d278c-4abc-4e21-8f29-f64b94b82ebf)


I noticed that `get_object_or_404()` in `tournament` is not handled by custom exception handling. For this one, I return json to the form so that it can display the error in the error message. This error can be reproduced by changing the value of input for tournament_id to an invalid value.

![image](https://github.com/user-attachments/assets/7f4e85b3-5d8d-43b2-bb83-2b65e43ad28b)
