### PR TITLE
ensure all path has trailing slash

### DIFF
--- a/srcs/backend/beePong/templates/beePong/home.html
+++ b/srcs/backend/beePong/templates/beePong/home.html
@@ -8,7 +8,7 @@
 					<p>Play solo against our vicious AI or gather friends and let the tournament decide who's the queen bee 🐝</p>
 				</div>
 				<div class="button-group--column">
-					<button class="button--primary button--with-icon" onclick="navigate(`{% url 'tournament:tournament' %}`, '/tournament')">
+					<button class="button--primary button--with-icon" onclick="navigate(`{% url 'tournament:tournament' %}`, `{% url 'tournament:tournament' %}`)">
 						TOURNAMENT
 						<img src="/img/arrow.svg" alt="arrow" width="21" height="12">
 					</button>

--- a/srcs/backend/tournament/templates/tournament/tournament_winner.html
+++ b/srcs/backend/tournament/templates/tournament/tournament_winner.html
@@ -3,5 +3,5 @@
 	
 	{% include 'tournament/tournament_name_list.html' %}
 	
-	<button class="button--primary" onclick="navigate(`{% url 'tournament:tournament' %}`, '/tournament')">BACK TO TOURNAMENTS</button>
+	<button class="button--primary" onclick="navigate(`{% url 'tournament:tournament' %}`, `{% url 'tournament:tournament' %}`)">BACK TO TOURNAMENTS</button>
 </section>

--- a/srcs/backend/tournament/views.py
+++ b/srcs/backend/tournament/views.py
@@ -46,7 +46,7 @@ def tournament(request):
                 if tournament.num_players_in >= tournament.num_players:
                    tournament.state = 'READY'
                 tournament.save()
-            return JsonResponse({'success': True, 'redirect': f'/tournament/{tournament_id}/lobby'}, status=201)
+            return JsonResponse({'success': True, 'redirect': f'/tournament/{tournament_id}/lobby/'}, status=201)
         else:
             return JsonResponse({'success': False, 'errors': form.errors}, status=400)
     
@@ -65,7 +65,7 @@ def tournament(request):
     return render(request, 'tournament/tournament.html', {
         'tournaments': tournament_data,
         'form': form,
-        'form_action': '/tournament/',
+        'form_action': reverse('tournament:tournament'),
     })
 
 
@@ -83,7 +83,7 @@ def create_tournament(request):
             form.save_m2m()
             return JsonResponse({
                 'success': True,
-                'redirect': '/tournament',
+                'redirect': reverse('tournament:tournament'),
                 'name': tournament.title,
                 'description': tournament.description,
                 'num_players': tournament.num_players,

--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -26,7 +26,7 @@
       </a>
       <ul>
         <li>
-          <a href="/about" onclick="navigate(event)">ABOUT</a>
+          <a href="/about/" onclick="navigate(event)">ABOUT</a>
         </li>
         <li id="navbar-user-actions"></li>
       </ul>

--- a/srcs/frontend/js/route.js
+++ b/srcs/frontend/js/route.js
@@ -22,14 +22,16 @@ export async function loadPage(path, redirectUrl = '/', fromNavigate = false, qu
 			if (!response.ok && response.status !== 404) {
 					if (response.status === 400 || response.status === 401) {
 						if (response.status === 400)
-							return loadPage('/accounts/oauth_error'); // Handle oauth error response by fetching the error page
+							return loadPage('/accounts/oauth_error/'); // Handle oauth error response by fetching the error page
 						else
-							return navigate('/accounts/login', redirectUrl); // Redirect to login page if the user is not authenticated	
+							return navigate('/accounts/login/', redirectUrl); // Redirect to login page if the user is not authenticated	
 					}
 					else {
 						throw new Error('Network response was not ok');
 					}
 			}
+
+
 
 			if (fromNavigate === true) // If this function is called by navigate(), update the browser's history to the new path without reloading the page
 				history.pushState(null, null, path);

--- a/srcs/frontend/js/tournament.js
+++ b/srcs/frontend/js/tournament.js
@@ -2,7 +2,7 @@
 // Mock WebSocket connection
 export function mockWebSocket() {
 	setTimeout(() => {
-		if (/^\/tournament\/\d+\/lobby$/.test(window.location.pathname))
+		if (/^\/tournament\/\d+\/lobby\/$/.test(window.location.pathname))
 			tournamentLobbyAddPlayer();
 	}, 1000); // Simulate a new player joining every second
 }
@@ -32,7 +32,7 @@ function tournamentLobbyAddPlayer() {
 // Handle full tournament lobby
 function handleFullTournamentLobby() {
 	setTimeout(() => {
-		if (/^\/tournament\/\d+\/lobby$/.test(window.location.pathname)) {
+		if (/^\/tournament\/\d+\/lobby\/$/.test(window.location.pathname)) {
 			document.getElementById('tournament-lobby-section').classList.add('full');
 			document.querySelector('.tournament_lobby__header').innerHTML = 'BEEPONG CUP IS STARTING IN <span id="countdown">3</span>...';
 			document.querySelector('.tournament_lobby__description').textContent = 'dummy vs dummy';
@@ -50,14 +50,14 @@ export function tournamentLobbyCountdown() {
 
   setTimeout(() => {
     const countdownInterval = setInterval(() => {
-			if (/^\/tournament\/\d+\/lobby$/.test(window.location.pathname))
+			if (/^\/tournament\/\d+\/lobby\/$/.test(window.location.pathname))
 			{
 				if (countdownValue > 1) {
 					countdownValue--;
 					countdownElement.textContent = `${countdownValue}`;
 				} else {
 					clearInterval(countdownInterval);
-					navigate('/game');
+					navigate('/game/');
 				}
 			}
 			else


### PR DESCRIPTION
@linhtng @liocle @djames9 

Here is the fix for the reload problem in login page reported in #75.

Now I add trailing slash to all paths to ensure it is consistent throughout the website. After going to the login page by clicking the tournament, if I click the login button in the navbar, it will not reload the login page again. 

There should be only one fetch no matter how many times I click the login button in the navbar.
![image](https://github.com/user-attachments/assets/f2f942e0-9e27-4da2-af58-0fb4fbcabf6e)

Close #75 
