### PR TITLE
Restore metricbeat.yml deleted during revert

### DIFF
--- a/elk/metricbeat.yml
+++ b/elk/metricbeat.yml
@@ -1,0 +1,58 @@
+metricbeat.config.modules:
+  path: ${path.config}/modules.d/*.yml
+  reload.enabled: false
+
+metricbeat.modules:
+- module: elasticsearch
+  xpack.enabled: true
+  period: 10s
+  hosts: ${ELASTIC_HOSTS}
+  username: ${ELASTIC_USER}
+  password: ${ELASTIC_PASSWORD}
+  ssl:
+    enabled: true
+    certificate_authorities: ${CA_CERT}
+
+- module: logstash
+  xpack.enabled: true
+  period: 10s
+  hosts: ${LOGSTASH_HOSTS}
+
+- module: kibana
+  metricsets: 
+    - stats
+  period: 10s
+  hosts: ${KIBANA_HOSTS}
+  username: ${ELASTIC_USER}
+  password: ${ELASTIC_PASSWORD}
+  xpack.enabled: true
+  ssl:
+    enabled: true
+    certificate_authorities: ${CA_CERT}
+
+- module: docker
+  metricsets:
+    - "container"
+    - "cpu"
+    - "diskio"
+    - "healthcheck"
+    - "info"
+    #- "image"
+    - "memory"
+    - "network"
+  hosts: ["unix:///var/run/docker.sock"]
+  period: 10s
+  enabled: true
+
+processors:
+  - add_host_metadata: ~
+  - add_docker_metadata: ~
+
+output.elasticsearch:
+  hosts: ${ELASTIC_HOSTS}
+  username: ${ELASTIC_USER}
+  password: ${ELASTIC_PASSWORD}
+  ssl:
+    enabled: true
+    certificate_authorities: ${CA_CERT}
+


### PR DESCRIPTION
@pixelsnow @linhtng  @wengcychan  @djames9 

## Restore `metricbeat.yml` Deleted During Revert

This pull request restores the `metricbeat.yml` file that was accidentally deleted during a previous revert ([commit hash: 0c710eb6f211e26a3f7f4273bc65d8aee7d963af](https://github.com/BeePong/42_transcendence/commit/0c710eb6f211e26a3f7f4273bc65d8aee7d963af)). 

### Changes:
- Re-adding `elk/metricbeat.yml`
