### PR TITLE
Feature/client side 404 handling

### DIFF
--- a/srcs/backend/accounts/views.py
+++ b/srcs/backend/accounts/views.py
@@ -108,16 +108,16 @@ database, they are logged in. If the user does not exist, a new user is created
 def oauth_token(request):
     code = request.GET.get('code')
     if code is None:
-        return redirect('/accounts/oauth_error/?from=oauth_token')
+        return redirect('/accounts/oauth_error?from=oauth_token')
 
     # Use the redirect url to frontend stored in state
     state = request.GET.get('state')
     if not state:
-        return redirect('/accounts/oauth_error/?from=oauth_token')
+        return redirect('/accounts/oauth_error?from=oauth_token')
     # Split the state to extract the redirect url
     state_parts = state.split('|')
     if len(state_parts) < 2:
-        return redirect('/accounts/oauth_error/?from=oauth_token')
+        return redirect('/accounts/oauth_error?from=oauth_token')
     redirect_url = unquote(state_parts[1])
 
     data = {
@@ -155,7 +155,7 @@ def oauth_token(request):
         login(request, user)
         return redirect(f'{redirect_url}?login=success')
     else:
-        return redirect('/accounts/oauth_error/?from=oauth_token')
+        return redirect('/accounts/oauth_error?from=oauth_token')
 
 """
 The oauth_error view handles the display of an OAuth error message.

--- a/srcs/backend/accounts/views.py
+++ b/srcs/backend/accounts/views.py
@@ -108,16 +108,16 @@ database, they are logged in. If the user does not exist, a new user is created
 def oauth_token(request):
     code = request.GET.get('code')
     if code is None:
-        return redirect('/accounts/oauth_error?from=oauth_token')
+        return redirect('/accounts/oauth_error/?from=oauth_token')
 
     # Use the redirect url to frontend stored in state
     state = request.GET.get('state')
     if not state:
-        return redirect('/accounts/oauth_error?from=oauth_token')
+        return redirect('/accounts/oauth_error/?from=oauth_token')
     # Split the state to extract the redirect url
     state_parts = state.split('|')
     if len(state_parts) < 2:
-        return redirect('/accounts/oauth_error?from=oauth_token')
+        return redirect('/accounts/oauth_error/?from=oauth_token')
     redirect_url = unquote(state_parts[1])
 
     data = {
@@ -155,7 +155,7 @@ def oauth_token(request):
         login(request, user)
         return redirect(f'{redirect_url}?login=success')
     else:
-        return redirect('/accounts/oauth_error?from=oauth_token')
+        return redirect('/accounts/oauth_error/?from=oauth_token')
 
 """
 The oauth_error view handles the display of an OAuth error message.

--- a/srcs/backend/beePong/urls.py
+++ b/srcs/backend/beePong/urls.py
@@ -7,6 +7,6 @@ urlpatterns = [
     path('navbar/', views.navbar, name='navbar'),
     path('home/', views.home, name='home'),
     path('about/', views.about, name='about'),
-    path('custom_404_frontend/', views.custom_404_frontend, name='custom_404_frontend'),
+    path('custom_404/', views.custom_404, name='custom_404'),
     path('health/', views.health_check, name='health_check'),
 ]

--- a/srcs/backend/beePong/urls.py
+++ b/srcs/backend/beePong/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     path('navbar/', views.navbar, name='navbar'),
     path('home/', views.home, name='home'),
     path('about/', views.about, name='about'),
+    path('custom_404_frontend/', views.custom_404_frontend, name='custom_404_frontend'),
     path('health/', views.health_check, name='health_check'),
 ]

--- a/srcs/backend/beePong/views.py
+++ b/srcs/backend/beePong/views.py
@@ -31,6 +31,10 @@ def about(request):
     """The about page for BeePong."""
     return render(request, 'beePong/about.html')
 
+def custom_404_frontend(request):
+    """The 404 page for BeePong."""
+    return render(request, 'beePong/error.html', {'error_message': '404 not found'}, status=404)
+
 def custom_404(request, exception):
     """The 404 page for BeePong."""
     return render(request, 'beePong/error.html', {'error_message': '404 not found'}, status=404)

--- a/srcs/backend/beePong/views.py
+++ b/srcs/backend/beePong/views.py
@@ -31,11 +31,7 @@ def about(request):
     """The about page for BeePong."""
     return render(request, 'beePong/about.html')
 
-def custom_404_frontend(request):
-    """The 404 page for BeePong."""
-    return render(request, 'beePong/error.html', {'error_message': '404 not found'}, status=404)
-
-def custom_404(request, exception):
+def custom_404(request, exception=None):
     """The 404 page for BeePong."""
     return render(request, 'beePong/error.html', {'error_message': '404 not found'}, status=404)
 

--- a/srcs/frontend/js/route.js
+++ b/srcs/frontend/js/route.js
@@ -9,10 +9,10 @@ const allowedRoutes = [
   '/tournament', 
   '/tournament/create',
 	'/accounts/oauth_error',
-  '/game' //TODO: replace by sole_game
 ];
 
 const tournamentLobbyPattern = /^\/tournament\/\d+\/lobby$/;
+const soloGamePattern = /^\/tournament\/\d+\/solo_game$/;
 
 // Handle navigation based on path or event
 function navigate(eventOrPath, redirectUrl = "/") {
@@ -48,7 +48,7 @@ export async function loadPage(
   // If the path is '/', set page to '/home'.
   // Otherwise, remove the trailing slash from the path and set page to the resulting string.
   const page = path === "/" ? "/home" : path.replace(/\/$/, "");
-  const isAllowed = allowedRoutes.includes(page) || tournamentLobbyPattern.test(page);
+  const isAllowed = allowedRoutes.includes(page) || tournamentLobbyPattern.test(page) || soloGamePattern.test(page);
   try {
     let response;
     if (isAllowed)

--- a/srcs/frontend/js/route.js
+++ b/srcs/frontend/js/route.js
@@ -1,6 +1,19 @@
 import { openWebSocket } from "./websockets.js";
 import { tournamentLobbyCountdown } from "./tournament.js";
 
+const allowedRoutes = [
+  '/home', 
+  '/about', 
+  '/accounts/login', 
+  '/accounts/register', 
+  '/tournament', 
+  '/tournament/create',
+	'/accounts/oauth_error',
+  '/game' //TODO: replace by sole_game
+];
+
+const tournamentLobbyPattern = /^\/tournament\/\d+\/lobby$/;
+
 // Handle navigation based on path or event
 function navigate(eventOrPath, redirectUrl = "/") {
   console.log("navigate");
@@ -35,8 +48,13 @@ export async function loadPage(
   // If the path is '/', set page to '/home'.
   // Otherwise, remove the trailing slash from the path and set page to the resulting string.
   const page = path === "/" ? "/home" : path.replace(/\/$/, "");
+  const isAllowed = allowedRoutes.includes(page) || tournamentLobbyPattern.test(page);
   try {
-    const response = await fetch(`/page${page}/${queryString}`);
+    let response;
+    if (isAllowed)
+      response = await fetch(`/page${page}/${queryString}`);
+    else
+      response = await fetch('/page/custom_404_frontend/');
 
     if (!response.ok && response.status !== 404) {
       if (

--- a/srcs/frontend/js/route.js
+++ b/srcs/frontend/js/route.js
@@ -2,13 +2,13 @@ import { openWebSocket } from "./websockets.js";
 import { tournamentLobbyCountdown } from "./tournament.js";
 
 const allowedRoutes = [
-  '/home', 
-  '/about', 
-  '/accounts/login', 
-  '/accounts/register', 
-  '/tournament', 
-  '/tournament/create',
-	'/accounts/oauth_error',
+  "/home",
+  "/about",
+  "/accounts/login",
+  "/accounts/register",
+  "/tournament",
+  "/tournament/create",
+  "/accounts/oauth_error",
 ];
 
 const tournamentLobbyPattern = /^\/tournament\/\d+\/lobby$/;
@@ -48,13 +48,14 @@ export async function loadPage(
   // If the path is '/', set page to '/home'.
   // Otherwise, remove the trailing slash from the path and set page to the resulting string.
   const page = path === "/" ? "/home" : path.replace(/\/$/, "");
-  const isAllowed = allowedRoutes.includes(page) || tournamentLobbyPattern.test(page) || soloGamePattern.test(page);
+  const isAllowed =
+    allowedRoutes.includes(page) ||
+    tournamentLobbyPattern.test(page) ||
+    soloGamePattern.test(page);
   try {
     let response;
-    if (isAllowed)
-      response = await fetch(`/page${page}/${queryString}`);
-    else
-      response = await fetch('/page/custom_404_frontend/');
+    if (isAllowed) response = await fetch(`/page${page}/${queryString}`);
+    else response = await fetch("/page/custom_404/");
 
     if (!response.ok && response.status !== 404) {
       if (


### PR DESCRIPTION
@pixelsnow @liocle @djames9 

Before the fix, page inside page will happen if django redirects valid path in urls.py such as https://localhost:8443/accounts/oauth_token or the navbar will show again inside the page in https://localhost:8443/navbar.

Now, this issue is fixed by implementing client side 404 handling. Valid pages should work as before and invalid url will show the custom 404 page.

Close #86
